### PR TITLE
 add ValidateSubs to MQTT client config;  MQTT remote module supports multiple remotes; use backoff for message republish in hub module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ openedge-remote-mqtt/openedge-remote-mqtt:
 test:
 	go test --race ./...
 
-tools: pubsub
+tools: pubsub consistency
 
 pubsub:
 	@echo "GO $@"

--- a/hub/rule/ruletopic_test.go
+++ b/hub/rule/ruletopic_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/baidu/openedge/hub/common"
 	"github.com/baidu/openedge/hub/config"
 	"github.com/baidu/openedge/hub/persist"
+	"github.com/jpillora/backoff"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -217,7 +218,11 @@ func TestRuleTopicRedo(t *testing.T) {
 	rc := int32(0)
 	var wg sync.WaitGroup
 	wg.Add(1)
-	rt.msgchan.republishTimeout = time.Millisecond * 100
+	rt.msgchan.republishBackoff = &backoff.Backoff{
+		Min:    time.Millisecond * 100,
+		Max:    time.Millisecond * 100,
+		Factor: 2,
+	}
 	rt.msgchan.publish = func(msg common.Message) {}
 	rt.msgchan.republish = func(msg common.Message) {
 		atomic.AddInt32(&rc, 1)

--- a/openedge-function/ruler.go
+++ b/openedge-function/ruler.go
@@ -54,15 +54,14 @@ func (rr *ruler) start() error {
 			rr.md.Send(puback)
 		}
 	})
-	err := rr.md.Start(func(pkt packet.Generic) {
-		switch p := pkt.(type) {
-		case *packet.Publish:
-			rr.fd.Invoke(p)
-		case *packet.Puback:
-			rr.md.Send(p)
-		}
-	})
-	return err
+	h := mqtt.Handler{}
+	h.ProcessPublish = func(p *packet.Publish) error {
+		return rr.fd.Invoke(p)
+	}
+	h.ProcessPuback = func(p *packet.Puback) error {
+		return rr.md.Send(p)
+	}
+	return rr.md.Start(h)
 }
 
 func (rr *ruler) close() {

--- a/openedge-remote-mqtt/conf.go
+++ b/openedge-remote-mqtt/conf.go
@@ -9,5 +9,24 @@ import (
 type Config struct {
 	module.Config `yaml:",inline" json:",inline"`
 	Hub           mqtt.ClientConfig `yaml:"hub" json:"hub"`
-	Remote        mqtt.ClientConfig `yaml:"remote" json:"remote"`
+	Remotes       []Remote          `yaml:"remotes" json:"remotes" default:"[]"`
+	Rules         []Rule            `yaml:"rules" json:"rules" default:"[]"`
+}
+
+// Remote remote config
+type Remote struct {
+	Name              string `yaml:"name" json:"name" validate:"nonzero"`
+	mqtt.ClientConfig `yaml:",inline" json:",inline"`
+}
+
+// Rule rule config
+type Rule struct {
+	ID  string `yaml:"id" json:"id"`
+	Hub struct {
+		Subscriptions []mqtt.Subscription `yaml:"subscriptions" json:"subscriptions" default:"[]"`
+	} `yaml:"hub" json:"hub"`
+	Remote struct {
+		Name          string              `yaml:"name" json:"name" validate:"nonzero"`
+		Subscriptions []mqtt.Subscription `yaml:"subscriptions" json:"subscriptions" default:"[]"`
+	} `yaml:"remote" json:"remote"`
 }

--- a/openedge-remote-mqtt/module.go
+++ b/openedge-remote-mqtt/module.go
@@ -1,76 +1,62 @@
 package main
 
 import (
-	"github.com/256dpi/gomqtt/packet"
+	"fmt"
+
 	"github.com/baidu/openedge/logger"
 	"github.com/baidu/openedge/module"
-	"github.com/baidu/openedge/trans/mqtt"
 	"github.com/sirupsen/logrus"
 )
 
 // mo bridge module of mqtt servers
 type mo struct {
-	conf   Config
-	hub    *mqtt.Dispatcher
-	remote *mqtt.Dispatcher
-	log    *logrus.Entry
+	cfg Config
+	rrs []*ruler
+	log *logrus.Entry
 }
 
 // New create a new module
 func New(confFile string) (module.Module, error) {
-	var conf Config
-	err := module.Load(&conf, confFile)
+	var cfg Config
+	err := module.Load(&cfg, confFile)
 	if err != nil {
 		return nil, err
 	}
-	logger.Init(conf.Logger, "module", conf.Name)
-	hub := mqtt.NewDispatcher(conf.Hub)
-	remote := mqtt.NewDispatcher(conf.Remote)
+	logger.Init(cfg.Logger, "module", cfg.Name)
+	remotes := make(map[string]Remote)
+	for _, remote := range cfg.Remotes {
+		remotes[remote.Name] = remote
+	}
+	rulers := make([]*ruler, 0)
+	for _, rule := range cfg.Rules {
+		remote, ok := remotes[rule.Remote.Name]
+		if !ok {
+			return nil, fmt.Errorf("remote (%s) not found", rule.Remote.Name)
+		}
+		rulers = append(rulers, create(rule, cfg.Hub, remote.ClientConfig))
+	}
 	return &mo{
-		conf:   conf,
-		hub:    hub,
-		remote: remote,
-		log:    logger.WithFields(),
+		cfg: cfg,
+		rrs: rulers,
+		log: logger.WithFields(),
 	}, nil
 }
 
 // Start starts module
 func (m *mo) Start() error {
-	err := m.hub.Start(func(pkt packet.Generic) {
-		err := m.remote.Send(pkt)
+	for _, ruler := range m.rrs {
+		err := ruler.start()
 		if err != nil {
-			m.log.WithError(err).Errorf("failed to send packet to remote")
+			m.log.WithError(err).Errorf("failed to start rule")
+			return err
 		}
-	})
-	if err != nil {
-		m.log.WithError(err).Errorf("failed to start hub dispatcher")
-		return err
-	}
-	err = m.remote.Start(func(pkt packet.Generic) {
-		err := m.hub.Send(pkt)
-		if err != nil {
-			m.log.WithError(err).Errorf("failed to send packet to hub")
-		}
-	})
-	if err != nil {
-		m.log.WithError(err).Errorf("failed to start remote dispatcher")
-		return err
 	}
 	return nil
 }
 
 // Close closes module
 func (m *mo) Close() {
-	if m.hub != nil {
-		err := m.hub.Close()
-		if err != nil {
-			m.log.WithError(err).Errorf("failed to close hub dispatcher")
-		}
-	}
-	if m.remote != nil {
-		err := m.remote.Close()
-		if err != nil {
-			m.log.WithError(err).Errorf("failed to close remote dispatcher")
-		}
+	for _, ruler := range m.rrs {
+		ruler.close()
 	}
 }

--- a/openedge-remote-mqtt/ruler.go
+++ b/openedge-remote-mqtt/ruler.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/256dpi/gomqtt/packet"
+	"github.com/baidu/openedge/trans/mqtt"
+	"github.com/docker/distribution/uuid"
+)
+
+type ruler struct {
+	r      *Rule
+	hub    *mqtt.Dispatcher
+	remote *mqtt.Dispatcher
+}
+
+func create(r Rule, hub, remote mqtt.ClientConfig) *ruler {
+	if r.ID != "" {
+		hub.CleanSession = false
+		remote.CleanSession = false
+		hub.ClientID = fmt.Sprintf("%s-%s", hub.ClientID, r.ID)
+		remote.ClientID = fmt.Sprintf("%s-%s", remote.ClientID, r.ID)
+	} else {
+		tmpid := uuid.Generate().String()
+		hub.CleanSession = false
+		remote.CleanSession = false
+		hub.ClientID = fmt.Sprintf("%s-%s", hub.ClientID, tmpid)
+		remote.ClientID = fmt.Sprintf("%s-%s", remote.ClientID, tmpid)
+	}
+	hub.Subscriptions = r.Hub.Subscriptions
+	remote.Subscriptions = r.Remote.Subscriptions
+	return &ruler{
+		r:      &r,
+		hub:    mqtt.NewDispatcher(hub),
+		remote: mqtt.NewDispatcher(remote),
+	}
+}
+
+func (rr *ruler) start() error {
+	hubHandler := mqtt.Handler{
+		ProcessPublish: func(p *packet.Publish) error {
+			return rr.remote.Send(p)
+		},
+		ProcessPuback: func(p *packet.Puback) error {
+			return rr.remote.Send(p)
+		},
+	}
+	if err := rr.hub.Start(hubHandler); err != nil {
+		return err
+	}
+	remoteHandler := mqtt.Handler{
+		ProcessPublish: func(p *packet.Publish) error {
+			return rr.hub.Send(p)
+		},
+		ProcessPuback: func(p *packet.Puback) error {
+			return rr.hub.Send(p)
+		},
+	}
+	if err := rr.remote.Start(remoteHandler); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (rr *ruler) close() {
+	rr.hub.Close()
+	rr.remote.Close()
+}

--- a/trans/mqtt/client.go
+++ b/trans/mqtt/client.go
@@ -15,14 +15,21 @@ import (
 	"gopkg.in/tomb.v2"
 )
 
+// Handler MQTT message handler
+type Handler struct {
+	ProcessPublish func(*packet.Publish) error
+	ProcessPuback  func(*packet.Puback) error
+	ProcessError   func(error)
+}
+
 // A Client connects to a broker and handles the transmission of packets
 type Client struct {
 	conn            transport.Conn
 	config          ClientConfig
+	handler         Handler
 	tracker         *client.Tracker
 	connectFuture   *Future
 	subscribeFuture *Future
-	callback        func(packet.Generic, error)
 
 	finish sync.Once
 	tomb   utils.Tomb
@@ -30,7 +37,7 @@ type Client struct {
 }
 
 // NewClient returns a new client
-func NewClient(cc ClientConfig, cb func(packet.Generic, error)) (*Client, error) {
+func NewClient(cc ClientConfig, handler Handler) (*Client, error) {
 	dialer, err := NewDialer(cc.Certificate)
 	if err != nil {
 		return nil, err
@@ -42,7 +49,7 @@ func NewClient(cc ClientConfig, cb func(packet.Generic, error)) (*Client, error)
 	c := &Client{
 		conn:            conn,
 		config:          cc,
-		callback:        cb,
+		handler:         handler,
 		connectFuture:   NewFuture(),
 		subscribeFuture: NewFuture(),
 		tracker:         client.NewTracker(cc.KeepAlive),
@@ -115,8 +122,12 @@ func (c *Client) Send(p packet.Generic) (err error) {
 	return
 }
 
-// Close closes the client immediately without sending a Disconnect packet and
-// waiting for outgoing transmissions to finish.
+// Dying returns the channel that can be used to wait until client closed
+func (c *Client) Dying() <-chan struct{} {
+	return c.tomb.Dying()
+}
+
+// Close closes the client after sending a disconnect packet
 func (c *Client) Close() error {
 	c.die(nil)
 	return c.tomb.Wait()
@@ -168,11 +179,20 @@ func (c *Client) processor() error {
 		}
 
 		switch p := pkt.(type) {
-		case *packet.Pingresp:
-			c.tracker.Pong()
-		case *packet.Connack:
-			err = client.ErrClientAlreadyConnecting
-			return c.die(err)
+		case *packet.Publish:
+			if c.handler.ProcessPublish != nil {
+				err = c.handler.ProcessPublish(p)
+				if err != nil {
+					return c.die(err)
+				}
+			}
+		case *packet.Puback:
+			if c.handler.ProcessPuback != nil {
+				err = c.handler.ProcessPuback(p)
+				if err != nil {
+					return c.die(err)
+				}
+			}
 		case *packet.Suback:
 			if c.config.ValidateSubs {
 				for _, code := range p.ReturnCodes {
@@ -183,10 +203,14 @@ func (c *Client) processor() error {
 				}
 			}
 			c.subscribeFuture.Complete()
+		case *packet.Pingresp:
+			c.tracker.Pong()
+		case *packet.Connack:
+			err = client.ErrClientAlreadyConnecting
+			return c.die(err)
 		default:
-			if c.callback != nil {
-				c.callback(pkt, nil)
-			}
+			err = client.ErrFailedSubscription
+			return c.die(err)
 		}
 	}
 }
@@ -255,7 +279,9 @@ func (c *Client) die(err error) error {
 		if err == nil {
 			c.send(packet.NewDisconnect(), false)
 		} else {
-			c.callback(nil, err)
+			if c.handler.ProcessError != nil {
+				c.handler.ProcessError(err)
+			}
 			c.log.WithError(err).Errorln("MQTT client raises error")
 		}
 		c.tomb.Kill(err)

--- a/trans/mqtt/client.go
+++ b/trans/mqtt/client.go
@@ -174,13 +174,15 @@ func (c *Client) processor() error {
 			err = client.ErrClientAlreadyConnecting
 			return c.die(err)
 		case *packet.Suback:
-			c.subscribeFuture.Complete()
-			for _, code := range p.ReturnCodes {
-				if code == packet.QOSFailure {
-					err = client.ErrFailedSubscription
-					return c.die(err)
+			if c.config.ValidateSubs {
+				for _, code := range p.ReturnCodes {
+					if code == packet.QOSFailure {
+						err = client.ErrFailedSubscription
+						return c.die(err)
+					}
 				}
 			}
+			c.subscribeFuture.Complete()
 		default:
 			if c.callback != nil {
 				c.callback(pkt, nil)

--- a/trans/mqtt/client_test.go
+++ b/trans/mqtt/client_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestClientConnectErrorMissingAddress(t *testing.T) {
-	c, err := mqtt.NewClient(mqtt.ClientConfig{}, nil)
+	c, err := mqtt.NewClient(mqtt.ClientConfig{}, mqtt.Handler{})
 	assert.EqualError(t, err, "parse : empty url")
 	assert.Nil(t, c)
 }
@@ -81,9 +81,9 @@ func TestClientConnectWithCredentials(t *testing.T) {
 	cc := newConfig(t, port)
 	cc.Username = "test"
 	cc.Password = "test"
-	cb := func(p packet.Generic, err error) {
+	cb := mqtt.Handler{ProcessError: func(err error) {
 		assert.EqualError(t, err, "connection refused: bad user name or password")
-	}
+	}}
 	c, err := mqtt.NewClient(cc, cb)
 	assert.EqualError(t, err, "connection refused: bad user name or password")
 	assert.Nil(t, c)
@@ -103,9 +103,9 @@ func TestClientConnectionDenied(t *testing.T) {
 	done, port := fakeBroker(t, broker)
 
 	cc := newConfig(t, port)
-	cb := func(p packet.Generic, err error) {
+	cb := mqtt.Handler{ProcessError: func(err error) {
 		assert.EqualError(t, err, "connection refused: not authorized")
-	}
+	}}
 	c, err := mqtt.NewClient(cc, cb)
 	assert.Nil(t, c)
 	assert.EqualError(t, err, "connection refused: not authorized")
@@ -122,9 +122,9 @@ func TestClientExpectedConnack(t *testing.T) {
 	done, port := fakeBroker(t, broker)
 
 	cc := newConfig(t, port)
-	cb := func(p packet.Generic, err error) {
+	cb := mqtt.Handler{ProcessError: func(err error) {
 		assert.EqualError(t, err, "client expected connack")
-	}
+	}}
 	c, err := mqtt.NewClient(cc, cb)
 	assert.Nil(t, c)
 	assert.EqualError(t, err, "client expected connack")
@@ -142,9 +142,9 @@ func TestClientNotExpectedConnack(t *testing.T) {
 	done, port := fakeBroker(t, broker)
 
 	cc := newConfig(t, port)
-	cb := func(p packet.Generic, err error) {
+	cb := mqtt.Handler{ProcessError: func(err error) {
 		assert.EqualError(t, err, "client already connecting")
-	}
+	}}
 	c, err := mqtt.NewClient(cc, cb)
 	assert.NoError(t, err)
 
@@ -202,9 +202,9 @@ func TestClientKeepAliveTimeout(t *testing.T) {
 
 	cc := newConfig(t, port)
 	cc.KeepAlive = time.Millisecond * 5
-	cb := func(p packet.Generic, err error) {
+	cb := mqtt.Handler{ProcessError: func(err error) {
 		assert.EqualError(t, err, "client missing pong")
-	}
+	}}
 	c, err := mqtt.NewClient(cc, cb)
 	assert.NoError(t, err)
 
@@ -241,15 +241,18 @@ func TestClientPublishSubscribeQOS0(t *testing.T) {
 
 	wait := make(chan struct{})
 
-	callback := func(pkt packet.Generic, err error) {
-		assert.NoError(t, err)
-		p, ok := pkt.(*packet.Publish)
-		assert.True(t, ok)
-		assert.Equal(t, "test", p.Message.Topic)
-		assert.Equal(t, []byte("test"), p.Message.Payload)
-		assert.Equal(t, packet.QOS(0), p.Message.QOS)
-		assert.False(t, p.Message.Retain)
-		close(wait)
+	callback := mqtt.Handler{
+		ProcessPublish: func(p *packet.Publish) error {
+			assert.Equal(t, "test", p.Message.Topic)
+			assert.Equal(t, []byte("test"), p.Message.Payload)
+			assert.Equal(t, packet.QOS(0), p.Message.QOS)
+			assert.False(t, p.Message.Retain)
+			close(wait)
+			return nil
+		},
+		ProcessError: func(err error) {
+			assert.NoError(t, err)
+		},
 	}
 	cc := newConfig(t, port)
 	cc.Subscriptions = []mqtt.Subscription{{Topic: "test"}}
@@ -301,18 +304,22 @@ func TestClientPublishSubscribeQOS1(t *testing.T) {
 
 	wait := make(chan struct{})
 
-	callback := func(pkt packet.Generic, err error) {
-		assert.NoError(t, err)
-		switch p := pkt.(type) {
-		case *packet.Publish:
+	callback := mqtt.Handler{
+		ProcessPublish: func(p *packet.Publish) error {
 			assert.Equal(t, "test", p.Message.Topic)
 			assert.Equal(t, []byte("test"), p.Message.Payload)
 			assert.Equal(t, packet.QOS(1), p.Message.QOS)
 			assert.False(t, p.Message.Retain)
 			close(wait)
-		case *packet.Puback:
+			return nil
+		},
+		ProcessPuback: func(p *packet.Puback) error {
 			assert.Equal(t, packet.ID(2), p.ID)
-		}
+			return nil
+		},
+		ProcessError: func(err error) {
+			assert.NoError(t, err)
+		},
 	}
 	cc := newConfig(t, port)
 	cc.Subscriptions = []mqtt.Subscription{{Topic: "test", QOS: 1}}
@@ -342,9 +349,9 @@ func TestClientUnexpectedClose(t *testing.T) {
 	done, port := fakeBroker(t, broker)
 
 	cc := newConfig(t, port)
-	cb := func(p packet.Generic, err error) {
+	cb := mqtt.Handler{ProcessError: func(err error) {
 		assert.EqualError(t, err, "client not connected")
-	}
+	}}
 	c, err := mqtt.NewClient(cc, cb)
 	assert.NoError(t, err)
 
@@ -363,9 +370,9 @@ func TestClientConnackFutureCancellation(t *testing.T) {
 	done, port := fakeBroker(t, broker)
 
 	cc := newConfig(t, port)
-	cb := func(p packet.Generic, err error) {
+	cb := mqtt.Handler{ProcessError: func(err error) {
 		assert.EqualError(t, err, "client not connected")
-	}
+	}}
 	c, err := mqtt.NewClient(cc, cb)
 	assert.Nil(t, c)
 	assert.EqualError(t, err, "client not connected")
@@ -382,9 +389,9 @@ func TestClientConnackFutureTimeout(t *testing.T) {
 
 	cc := newConfig(t, port)
 	cc.Timeout = time.Millisecond * 50
-	cb := func(p packet.Generic, err error) {
+	cb := mqtt.Handler{ProcessError: func(err error) {
 		assert.EqualError(t, err, "future timeout")
-	}
+	}}
 	c, err := mqtt.NewClient(cc, cb)
 	assert.Nil(t, c)
 	assert.EqualError(t, err, "future timeout")
@@ -408,9 +415,9 @@ func TestClientSubscribeFutureTimeout(t *testing.T) {
 	cc := newConfig(t, port)
 	cc.Timeout = time.Millisecond * 50
 	cc.Subscriptions = []mqtt.Subscription{mqtt.Subscription{Topic: "test"}}
-	cb := func(p packet.Generic, err error) {
+	cb := mqtt.Handler{ProcessError: func(err error) {
 		assert.EqualError(t, err, "future timeout")
-	}
+	}}
 	c, err := mqtt.NewClient(cc, cb)
 	assert.Nil(t, c)
 	assert.EqualError(t, err, "future timeout")
@@ -439,9 +446,9 @@ func TestClientSubscribeValidate(t *testing.T) {
 	cc := newConfig(t, port)
 	cc.ValidateSubs = true
 	cc.Subscriptions = []mqtt.Subscription{mqtt.Subscription{Topic: "test"}}
-	cb := func(p packet.Generic, err error) {
+	cb := mqtt.Handler{ProcessError: func(err error) {
 		assert.EqualError(t, err, "failed subscription")
-	}
+	}}
 	c, err := mqtt.NewClient(cc, cb)
 	assert.Nil(t, c)
 	assert.EqualError(t, err, "failed subscription")
@@ -470,8 +477,7 @@ func TestClientSubscribeWithoutValidate(t *testing.T) {
 
 	cc := newConfig(t, port)
 	cc.Subscriptions = []mqtt.Subscription{mqtt.Subscription{Topic: "test"}}
-	cb := func(p packet.Generic, err error) {}
-	c, err := mqtt.NewClient(cc, cb)
+	c, err := mqtt.NewClient(cc, mqtt.Handler{})
 	assert.NotNil(t, c)
 	assert.NoError(t, err)
 

--- a/trans/mqtt/config.go
+++ b/trans/mqtt/config.go
@@ -22,6 +22,7 @@ type ClientConfig struct {
 	Interval      time.Duration  `yaml:"interval" json:"interval" default:"1m"`
 	KeepAlive     time.Duration  `yaml:"keepalive" json:"keepalive" default:"1m"`
 	BufferSize    int            `yaml:"buffersize" json:"buffersize" default:"10"`
+	ValidateSubs  bool           `yaml:"validatesubs" json:"validatesubs"`
 	Subscriptions []Subscription `yaml:"subscriptions" json:"subscriptions" default:"[]"`
 
 	Username          string `yaml:"username" json:"username"`

--- a/trans/mqtt/utils_test.go
+++ b/trans/mqtt/utils_test.go
@@ -28,11 +28,12 @@ func newConfig(t *testing.T, port string) (c mqtt.ClientConfig) {
 	return
 }
 
-func assertNoErrorCallback(t *testing.T) func(packet.Generic, error) {
-	return func(p packet.Generic, err error) {
+func assertNoErrorCallback(t *testing.T) (h mqtt.Handler) {
+	h.ProcessError = func(err error) {
 		assert.NoError(t, err)
-		assert.FailNow(t, "callback should not have been called")
+		assert.FailNow(t, "ProcessError should not have been called")
 	}
+	return
 }
 
 func fakeBroker(t *testing.T, testFlows ...*flow.Flow) (chan struct{}, string) {


### PR DESCRIPTION
#25 add ValidateSubs to MQTT client config to check subscribe result or not ;  
#21 MQTT remote module supports multiple remotes; 
#27 use backoff for message republish in hub module. 