### PR TITLE
clean up old instances if exists when openedge starts

### DIFF
--- a/master/engine/docker/container.go
+++ b/master/engine/docker/container.go
@@ -50,63 +50,6 @@ func (e *dockerEngine) initNetwork() error {
 	return nil
 }
 
-// func (e *dockerEngine) monitoring() error {
-// 	ctx := context.Background()
-// 	options := types.EventsOptions{
-// 		Filters: filters.NewArgs(
-// 			filters.Arg("type", "container"),
-// 			filters.Arg("event", "restart"),
-// 			filters.Arg("label", "openedge"),
-// 		),
-// 	}
-// 	eventC, errC := e.cli.Events(ctx, options)
-// 	for {
-// 		select {
-// 		case event := <-eventC:
-// 			if event.Action != "restart" {
-// 				e.log.Warnf("unexpected event action (%s) from docker engine", event.Action)
-// 				continue
-// 			}
-// 			if _, ok := event.Actor.Attributes["openedge"]; !ok {
-// 				e.log.Debugf("docker container (%s) is not managed by openedge", event.Actor.ID[:12])
-// 				continue
-// 			}
-// 			serviceName, ok := event.Actor.Attributes["service"]
-// 			if !ok {
-// 				e.log.Warnf("unexpected docker container (%s) without service name", event.Actor.ID[:12])
-// 				continue
-// 			}
-// 			instanceName, ok := event.Actor.Attributes["name"]
-// 			if !ok {
-// 				e.log.Warnf("unexpected docker container (%s) without instance name", event.Actor.ID[:12])
-// 				continue
-// 			}
-// 			status, err := e.cli.ContainerInspect(ctx, event.Actor.ID)
-// 			if err != nil {
-// 				e.log.WithError(err).Warnf("failed to inspect container (%s)", event.Actor.ID[:12])
-// 				return nil, err
-// 			}
-// 			stats, err := e.statsContainer(event.Actor.ID)
-// 			if err != nil {
-// 				e.log.Warnf("failed to stats container (%s)", event.Actor.ID[:12])
-// 				e.stats.UpdateInstanceStats(serviceName, instanceName, map[string]interface{}{
-// 					"status": engine.Offline,
-// 				})
-// 				i.SetStatus(engine.Offline)
-// 			} else {
-// 				i.SetStats(s)
-// 			}
-// 			return i.Stats()
-// 			serviceName := event.Status
-// 		case err := <-errC:
-// 			e.log.Errorf("failed to monitor events from docker engine, to retry")
-// 			eventC, errC = e.cli.Events(ctx, options)
-// 		case <-e.tomb.Dying():
-// 			return nil
-// 		}
-// 	}
-// }
-
 func (e *dockerEngine) pullImage(name string) error {
 	out, err := e.cli.ImagePull(context.Background(), name, types.ImagePullOptions{})
 	if err != nil {
@@ -220,45 +163,3 @@ func (e *dockerEngine) removeContainerByName(name string) error {
 	}
 	return err
 }
-
-// func (e *dockerEngine) statsContainer(cid string) (map[string]interface{}, error) {
-// 	ctx := context.Background()
-// 	status, err := e.cli.ContainerInspect(ctx, cid)
-// 	if err != nil {
-// 		e.log.WithError(err).Warnf("failed to inspect container (%s)", cid[:12])
-// 		return nil, err
-// 	}
-// 	resp, err := e.cli.ContainerStats(ctx, cid, false)
-// 	if err != nil {
-// 		e.log.WithError(err).Warnf("failed to stats container (%s)", cid[:12])
-// 		return nil, err
-// 	}
-// 	defer resp.Body.Close()
-// 	data, err := ioutil.ReadAll(resp.Body)
-// 	if err != nil {
-// 		e.log.WithError(err).Warnf("failed to read stats response of container (%s)", cid[:12])
-// 		return nil, err
-// 	}
-// 	var stats types.Stats
-// 	err = json.Unmarshal(data, &stats)
-// 	if err != nil {
-// 		e.log.WithError(err).Warnf("failed to unmarshal stats response of container (%s)", cid[:12])
-// 		return nil, err
-// 	}
-
-// 	stats.MemoryStats.Stats = nil
-// 	cpuStats := map[string]interface{}{
-// 		"online_cpus":         stats.CPUStats.OnlineCPUs,
-// 		"system_cpu_usage":    stats.CPUStats.SystemUsage,
-// 		"total_usage":         stats.CPUStats.CPUUsage.TotalUsage,
-// 		"usage_in_kernelmode": stats.CPUStats.CPUUsage.UsageInKernelmode,
-// 		"usage_in_usermode":   stats.CPUStats.CPUUsage.UsageInUsermode,
-// 	}
-// 	return map[string]interface{}{
-// 		"status":      status.State.Status,
-// 		"start_time":  status.State.StartedAt,
-// 		"finish_time": status.State.FinishedAt,
-// 		"cpu_stats":   cpuStats,
-// 		"mem_stats":   stats.MemoryStats,
-// 	}, nil
-// }

--- a/master/engine/docker/instance.go
+++ b/master/engine/docker/instance.go
@@ -6,6 +6,21 @@ import (
 	"github.com/baidu/openedge/utils"
 )
 
+type attribute struct {
+	Name      string `yaml:"name" json:"name"`
+	Container struct {
+		ID   string `yaml:"id" json:"id"`
+		Name string `yaml:"name" json:"name"`
+	} `yaml:"container" json:"container"`
+}
+
+func (a attribute) toPartialStats() engine.PartialStats {
+	return engine.PartialStats{
+		engine.KeyName: a.Name,
+		"container":    a.Container,
+	}
+}
+
 // Instance instance of service
 type dockerInstance struct {
 	id      string
@@ -45,16 +60,20 @@ func (s *dockerService) newInstance(name string, params containerConfigs) (*dock
 	return i, nil
 }
 
-func (i *dockerInstance) ID() string {
-	return i.id
+func (i *dockerInstance) Service() engine.Service {
+	return i.service
 }
 
 func (i *dockerInstance) Name() string {
 	return i.name
 }
 
-func (i *dockerInstance) Service() engine.Service {
-	return i.service
+func (i *dockerInstance) Info() engine.PartialStats {
+	var attr attribute
+	attr.Name = i.name
+	attr.Container.ID = i.id
+	attr.Container.Name = i.name
+	return attr.toPartialStats()
 }
 
 func (i *dockerInstance) Wait(s chan<- error) {

--- a/master/engine/infostats.go
+++ b/master/engine/infostats.go
@@ -18,6 +18,7 @@ func NewPartialStatsByStatus(status string) PartialStats {
 
 // InfoStats interfaces of the storage of info and stats
 type InfoStats interface {
+	LoadStats(sss interface{}) bool
 	AddInstanceStats(serviceName, instanceName string, partialStats PartialStats)
 	DelInstanceStats(serviceName, instanceName string)
 }

--- a/master/engine/instance.go
+++ b/master/engine/instance.go
@@ -10,7 +10,6 @@ import (
 
 // all status
 const (
-	KeyID         = "id"
 	KeyName       = "name"
 	KeyStatus     = "status"
 	KeyCreateTime = "create_time"
@@ -29,9 +28,9 @@ const (
 
 // Instance interfaces of instance
 type Instance interface {
-	ID() string
-	Name() string
 	Service() Service
+	Name() string
+	Info() PartialStats
 	Wait(w chan<- error)
 	Dying() <-chan struct{}
 	Restart() error

--- a/master/engine/supervisor.go
+++ b/master/engine/supervisor.go
@@ -28,12 +28,10 @@ func Supervising(instance Instance) error {
 	l := logger.Global.WithField("service", serviceName).WithField("instance", instanceName)
 	s := make(chan error, 1)
 	for {
-		_engine.AddInstanceStats(serviceName, instanceName, PartialStats{
-			KeyID:        instance.ID(),
-			KeyName:      instance.Name(),
-			KeyStatus:    Running,
-			KeyStartTime: time.Now().UTC(),
-		})
+		instanceInfo := instance.Info()
+		instanceInfo[KeyStatus]=Running
+		instanceInfo[KeyStartTime]=time.Now().UTC()
+		_engine.AddInstanceStats(serviceName, instanceName, instanceInfo)
 		go instance.Wait(s)
 		select {
 		case <-instance.Dying():


### PR DESCRIPTION
In the case of openedge master existing abnormally, the services may not have exited. After restarting, clean up the old services then start new service
TODO：
1. process name not match for function python instance, will cause process to fail to kill
2. openedge.pid not deleted when openedge exits abnormally, will cause openedge to fail to start