### PR TITLE
increase the timeout of http server and client

### DIFF
--- a/protocol/http/config.go
+++ b/protocol/http/config.go
@@ -9,15 +9,15 @@ import (
 // ServerInfo http server config
 type ServerInfo struct {
 	Address           string        `yaml:"address" json:"address"`
-	Timeout           time.Duration `yaml:"timeout" json:"timeout" default:"30s"`
+	Timeout           time.Duration `yaml:"timeout" json:"timeout" default:"5m"`
 	utils.Certificate `yaml:",inline" json:",inline"`
 }
 
 // ClientInfo http client config
 type ClientInfo struct {
 	Address           string        `yaml:"address" json:"address"`
-	Timeout           time.Duration `yaml:"timeout" json:"timeout" default:"30s"`
-	KeepAlive         time.Duration `yaml:"keepalive" json:"keepalive" default:"60s"`
+	Timeout           time.Duration `yaml:"timeout" json:"timeout" default:"5m"`
+	KeepAlive         time.Duration `yaml:"keepalive" json:"keepalive" default:"10m"`
 	Username          string        `yaml:"username" json:"username"`
 	Password          string        `yaml:"password" json:"password"`
 	utils.Certificate `yaml:",inline" json:",inline"`


### PR DESCRIPTION
If the edge device is in a poor network, the volume download will be slow, so increases the timeout of http server and client