### PR TITLE
bce-iot-9393: correct the cpu percent and ignore empty stats

### DIFF
--- a/master/engine/docker/container.go
+++ b/master/engine/docker/container.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"runtime"
 	"time"
 
 	"github.com/baidu/openedge/master/engine"
@@ -176,23 +177,34 @@ func (e *dockerEngine) statsContainer(cid string) engine.PartialStats {
 		return engine.PartialStats{"error": err.Error()}
 	}
 	defer sresp.Body.Close()
-	// TODO: to use json.NewEncoder(sresp.Body).Encode(&types.StatsJSON{})
-	data, err := ioutil.ReadAll(sresp.Body)
+	var tstats types.Stats
+	err = json.NewDecoder(sresp.Body).Decode(&tstats)
 	if err != nil {
 		e.log.WithError(err).Warnf("failed to read stats response of container (%s)", cid[:12])
 		return engine.PartialStats{"error": err.Error()}
 	}
-	var tstats types.Stats
-	err = json.Unmarshal(data, &tstats)
-	if err != nil {
-		e.log.WithError(err).Warnf("failed to unmarshal stats response of container (%s)", cid[:12])
-		return engine.PartialStats{"error": err.Error()}
+
+	if tstats.Read.IsZero() || tstats.PreRead.IsZero() {
+		return nil
+	}
+
+	var cpuPercent = 0.0
+	if runtime.GOOS != "windows" {
+		cpuDelta := float64(tstats.CPUStats.CPUUsage.TotalUsage - tstats.PreCPUStats.CPUUsage.TotalUsage)
+		systemDelta := float64(tstats.CPUStats.SystemUsage - tstats.PreCPUStats.SystemUsage)
+		cpuPercent = (cpuDelta / systemDelta) * float64(len(tstats.CPUStats.CPUUsage.PercpuUsage))
+	} else {
+		possIntervals := uint64(tstats.Read.Sub(tstats.PreRead).Nanoseconds()) / 100 * uint64(tstats.NumProcs)
+		intervalsUsed := tstats.CPUStats.CPUUsage.TotalUsage - tstats.PreCPUStats.CPUUsage.TotalUsage
+		if possIntervals > 0 {
+			cpuPercent = float64(intervalsUsed) / float64(possIntervals)
+		}
 	}
 
 	return engine.PartialStats{
 		"cpu_stats": utils.CPUInfo{
 			Time:        t,
-			UsedPercent: float64(tstats.CPUStats.CPUUsage.TotalUsage) / float64(tstats.CPUStats.SystemUsage),
+			UsedPercent: cpuPercent,
 		},
 		"mem_stats": utils.MemInfo{
 			Time:        t,


### PR DESCRIPTION
bugfix: correct the cpu percent and ignore empty stats in docker container mode